### PR TITLE
Relax dependency constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,14 @@
     ],
 
     "require": {
-        "nelmio/solarium-bundle": "^2.2|^3.0",
         "php": ">=5.3.0",
-        "symfony/config": "^2.3|^3.0|^4.0",
-        "symfony/console": "^2.3|^3.0|^4.0",
-        "symfony/dependency-injection": "^2.3|^3.0|^4.0",
-        "symfony/http-kernel": "^2.3|^3.0|^4.0",
+        "nelmio/solarium-bundle": "^2.2|^3.0|^4.0|^5.0",
+        "psr/log": "^1.0",
+        "solarium/solarium": "^4.2|^5.0|^6.0",
+        "symfony/config": "^2.3|^3.0|^4.0|^5.0",
+        "symfony/console": "^2.3|^3.0|^4.0|^5.0",
+        "symfony/dependency-injection": "^2.3|^3.0|^4.0|^5.0",
+        "symfony/http-kernel": "^2.3|^3.0|^4.0|^5.0",
         "webfactory/content-mapping-destinationadapter-solarium": "^1.2.0"
     },
 
@@ -27,7 +29,7 @@
             "Webfactory\\ContentMappingDestinationAdapterSolariumBundle\\": "src"
         }
     },
-    
+
     "config": {
         "sort-packages": true
     }


### PR DESCRIPTION
This bundle contains so little code that, after a brief skim of the appropriate UPGRADING/CHANGELOG documents, it seems reasonably safe to declare compatibility with a broad range of package versions.
